### PR TITLE
feat: add nr1-graphiql-notebook submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -26,3 +26,6 @@
 [submodule "apps/nr1-github"]
 	path = apps/nr1-github
 	url = https://github.com/newrelic/nr1-github.git
+[submodule "apps/nr1-graphiql-notebook"]
+	path = apps/nr1-graphiql-notebook
+	url = https://github.com/newrelic/nr1-graphiql-notebook.git


### PR DESCRIPTION
Adding nr1-graphiql-notebook as a submodule. Current release is v0.6.0